### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,8 +2,8 @@
 
 * 用法
 #+begin_src julia
-  using pipeline
-  @pipeline 1 begin
+  using Pipeline
+  Pipeline.@pipeline 1 begin
       x -> x + 1
       x -> x * 2
       x -> x / 3


### PR DESCRIPTION
修改了readme，让例子可以在REPL里正确调用。
```@pipeline```在包里没有```export```，所以需要使用```Pipeline.@pipeline```。